### PR TITLE
Align URL schema with packaged repositories

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
-google_chrome_rpm_repo: "http://dl.google.com/linux/chrome/rpm/stable/x86_64"
+google_chrome_base_url: https://dl.google.com/linux/chrome
+google_chrome_rpm_repo: "{{ google_chrome_base_url }}/rpm/stable/x86_64"
 google_chrome_gpgkey: https://dl.google.com/linux/linux_signing_key.pub

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -11,7 +11,7 @@
 
 - name: Google Chrome APT repo added
   apt_repository:
-    repo: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
+    repo: "deb [arch=amd64] {{ google_chrome_base_url }}/deb/ stable main"
     filename: google-chrome
     state: present
   become: yes


### PR DESCRIPTION
At least for Debian, the packaged repository configuration uses `https` instead of `https`. Lets align the role to avoid changed states after the setup.

- Added `base_url` variable using `https` instead of `http`